### PR TITLE
Fix: Fatal error: During inheritance of ArrayAccess in PHP 8.1

### DIFF
--- a/Slim/Environment.php
+++ b/Slim/Environment.php
@@ -183,7 +183,7 @@ class Environment implements \ArrayAccess, \IteratorAggregate
     /**
      * Array Access: Offset Exists
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->properties[$offset]);
     }
@@ -191,7 +191,7 @@ class Environment implements \ArrayAccess, \IteratorAggregate
     /**
      * Array Access: Offset Get
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         if (isset($this->properties[$offset])) {
             return $this->properties[$offset];
@@ -203,7 +203,7 @@ class Environment implements \ArrayAccess, \IteratorAggregate
     /**
      * Array Access: Offset Set
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->properties[$offset] = $value;
     }
@@ -211,7 +211,7 @@ class Environment implements \ArrayAccess, \IteratorAggregate
     /**
      * Array Access: Offset Unset
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->properties[$offset]);
     }
@@ -221,7 +221,7 @@ class Environment implements \ArrayAccess, \IteratorAggregate
      *
      * @return \ArrayIterator
      */
-    public function getIterator()
+    public function getIterator(): \Iterator
     {
         return new \ArrayIterator($this->properties);
     }

--- a/Slim/Helper/Set.php
+++ b/Slim/Helper/Set.php
@@ -175,22 +175,22 @@ class Set implements \ArrayAccess, \Countable, \IteratorAggregate
      * Array Access
      */
 
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return $this->has($offset);
     }
 
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return $this->get($offset);
     }
 
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->set($offset, $value);
     }
 
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         $this->remove($offset);
     }
@@ -199,7 +199,7 @@ class Set implements \ArrayAccess, \Countable, \IteratorAggregate
      * Countable
      */
 
-    public function count()
+    public function count(): int
     {
         return count($this->data);
     }
@@ -208,7 +208,7 @@ class Set implements \ArrayAccess, \Countable, \IteratorAggregate
      * IteratorAggregate
      */
 
-    public function getIterator()
+    public function getIterator(): \Iterator
     {
         return new \ArrayIterator($this->data);
     }

--- a/Slim/Http/Response.php
+++ b/Slim/Http/Response.php
@@ -435,7 +435,7 @@ class Response implements \ArrayAccess, \Countable, \IteratorAggregate
      * Helpers: Server Error?
      * @return bool
      */
-    public function isServerError(): bool
+    public function isServerError()
     {
         return $this->status >= 500 && $this->status < 600;
     }

--- a/Slim/Http/Response.php
+++ b/Slim/Http/Response.php
@@ -448,7 +448,7 @@ class Response implements \ArrayAccess, \Countable, \IteratorAggregate
     /**
      * Array Access: Offset Exists
      */
-    public function offsetExists($offset) : bool
+    public function offsetExists($offset): bool
     {
         return isset($this->headers[$offset]);
     }

--- a/Slim/Http/Response.php
+++ b/Slim/Http/Response.php
@@ -435,7 +435,7 @@ class Response implements \ArrayAccess, \Countable, \IteratorAggregate
      * Helpers: Server Error?
      * @return bool
      */
-    public function isServerError()
+    public function isServerError(): bool
     {
         return $this->status >= 500 && $this->status < 600;
     }
@@ -448,7 +448,7 @@ class Response implements \ArrayAccess, \Countable, \IteratorAggregate
     /**
      * Array Access: Offset Exists
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset) : bool
     {
         return isset($this->headers[$offset]);
     }
@@ -456,7 +456,7 @@ class Response implements \ArrayAccess, \Countable, \IteratorAggregate
     /**
      * Array Access: Offset Get
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return $this->headers[$offset];
     }
@@ -464,7 +464,7 @@ class Response implements \ArrayAccess, \Countable, \IteratorAggregate
     /**
      * Array Access: Offset Set
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->headers[$offset] = $value;
     }
@@ -472,7 +472,7 @@ class Response implements \ArrayAccess, \Countable, \IteratorAggregate
     /**
      * Array Access: Offset Unset
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->headers[$offset]);
     }
@@ -483,7 +483,7 @@ class Response implements \ArrayAccess, \Countable, \IteratorAggregate
      *
      * Countable: Count
      */
-    public function count()
+    public function count(): int
     {
         return count($this->headers);
     }
@@ -499,7 +499,7 @@ class Response implements \ArrayAccess, \Countable, \IteratorAggregate
      *
      * @return \Slim\Http\Headers
      */
-    public function getIterator()
+    public function getIterator(): \Iterator
     {
         return $this->headers->getIterator();
     }

--- a/Slim/Middleware/Flash.php
+++ b/Slim/Middleware/Flash.php
@@ -155,7 +155,7 @@ class Flash extends \Slim\Middleware implements \ArrayAccess, \IteratorAggregate
     /**
      * Array Access: Offset Exists
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         $messages = $this->getMessages();
 
@@ -165,7 +165,7 @@ class Flash extends \Slim\Middleware implements \ArrayAccess, \IteratorAggregate
     /**
      * Array Access: Offset Get
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         $messages = $this->getMessages();
 
@@ -175,7 +175,7 @@ class Flash extends \Slim\Middleware implements \ArrayAccess, \IteratorAggregate
     /**
      * Array Access: Offset Set
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->now($offset, $value);
     }
@@ -183,7 +183,7 @@ class Flash extends \Slim\Middleware implements \ArrayAccess, \IteratorAggregate
     /**
      * Array Access: Offset Unset
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->messages['prev'][$offset], $this->messages['now'][$offset]);
     }
@@ -192,7 +192,7 @@ class Flash extends \Slim\Middleware implements \ArrayAccess, \IteratorAggregate
      * Iterator Aggregate: Get Iterator
      * @return \ArrayIterator
      */
-    public function getIterator()
+    public function getIterator(): \Iterator
     {
         $messages = $this->getMessages();
 
@@ -202,7 +202,7 @@ class Flash extends \Slim\Middleware implements \ArrayAccess, \IteratorAggregate
     /**
      * Countable: Count
      */
-    public function count()
+    public function count(): int
     {
         return count($this->getMessages());
     }


### PR DESCRIPTION
Problem:

For PHP 8.1, if `error_reporting` set to `E_ALL`, it will throw exception like this:

```
Fatal error: During inheritance of ArrayAccess: Uncaught ErrorException: 

Return type of Slim\Http\Response::offsetExists($offset) should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /var/www/html/vendor/gammadia/slim-2.x/Slim/Http/Response.php:451
```

This pull request:

Add missing return types to all related methods in order to solve the issue.