### PR TITLE
Fix null HTTP_COOKIE, rtrim first param must be string

### DIFF
--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -84,7 +84,7 @@ class Request
     {
         $this->env = $env;
         $this->headers = new \Slim\Http\Headers(\Slim\Http\Headers::extract($env));
-        $this->cookies = new \Slim\Helper\Set(\Slim\Http\Util::parseCookieHeader($env['HTTP_COOKIE']));
+        $this->cookies = new \Slim\Helper\Set(\Slim\Http\Util::parseCookieHeader($env['HTTP_COOKIE'] ?? ''));
     }
 
     /**


### PR DESCRIPTION
@gnutix small fix, php 8.1 compatibility