### PR TITLE
Tech: fix deprecation

### DIFF
--- a/Slim/Http/Response.php
+++ b/Slim/Http/Response.php
@@ -241,7 +241,7 @@ class Response implements \ArrayAccess, \Countable, \IteratorAggregate
         } else {
             $this->body .= (string)$body;
         }
-        $this->length = strlen($this->body);
+        $this->length = strlen($this->body ?? '');
 
         return $this->body;
     }


### PR DESCRIPTION
Starting from PHP 8.1, passing `null` to `strlen` is deprecated.