### PR TITLE
Tech: fix deprecation

### DIFF
--- a/Slim/Http/Response.php
+++ b/Slim/Http/Response.php
@@ -237,7 +237,7 @@ class Response implements \ArrayAccess, \Countable, \IteratorAggregate
     public function write($body, $replace = false)
     {
         if ($replace) {
-            $this->body = $body;
+            $this->body = (string)$body;
         } else {
             $this->body .= (string)$body;
         }


### PR DESCRIPTION
Starting from PHP 8.1, passing `null` to `strlen` is deprecated.